### PR TITLE
Validates Integration in a real Symfony Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ final class Order
 }
 
 // Or use Doctrine Annotations (requires separate install):
+// In order to use Annotations you have to install `doctrine/annotations` via `composer require doctrine/annotations`
 
 /**
  * @Violines\RestBundle\HttpApi\HttpApi
@@ -128,3 +129,4 @@ For more details please check [violines/rest-bundle Wiki](https://github.com/vio
 1. cd docker/
 1. pull latest image(s): docker-compose pull
 1. create the container(s): docker-compose up -d
+    - To run the tests in one of the containers, use `docker-compose exec php80 composer run test`

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
         "phpunit/phpunit": "^9.3.0",
         "rector/rector": "^0.8.6",
         "symfony/property-access": "^4.4 || ^5.0",
-        "vimeo/psalm": "^4.0"
+        "vimeo/psalm": "^4.0",
+        "symfony/framework-bundle": "^4.4 || ^5.2",
+        "symfony/filesystem": "^4.4 || ^5.2"
     },
     "conflict": {
         "symfony/event-dispatcher": "<4.4"

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -47,7 +47,7 @@ final class ControllerTest extends TestCase
 
         self::assertSame(MimeTypes::APPLICATION_JSON, $response->headers->get('Content-Type'));
         self::assertJsonStringEqualsJsonString(<<<JSON
-            {"from":"Forest"}
+            {"to":"Forest"}
        JSON, $response->getContent());
     }
 
@@ -61,16 +61,16 @@ final class ControllerTest extends TestCase
         self::assertSame(MimeTypes::APPLICATION_JSON, $response->headers->get('Content-Type'));
         self::assertJsonStringEqualsJsonString(<<<JSON
             [
-                {"from":"Jenny"},
-                {"from":"Forest"}
+                {"to":"Jenny"},
+                {"to":"Forest"}
             ]
        JSON, $response->getContent());
     }
 
-    public function testReconstitutesOneFromRequest(): void
+    public function testReconstitutesOnetoRequest(): void
     {
         $submitted = <<<JSON
-            {"from":"Jenny"}
+            {"to":"Jenny"}
         JSON;
 
         $request = Request::create('/reconstitutesOne', Request::METHOD_POST, [], [], [], [], $submitted);
@@ -82,12 +82,12 @@ final class ControllerTest extends TestCase
         self::assertJsonStringEqualsJsonString($submitted, $response->getContent());
     }
 
-    public function testReconstitutesMultipleFromRequest(): void
+    public function testReconstitutesMultipletoRequest(): void
     {
         $submitted = <<<JSON
             [
-                {"from":"Jenny"},
-                {"from":"Forest"}
+                {"to":"Jenny"},
+                {"to":"Forest"}
             ]
         JSON;
 
@@ -181,23 +181,14 @@ final class HugController
 {
     public function returnsOne(): Hug
     {
-        $fromForest = new Hug();
-        $fromForest->from = 'Forest';
-
-        return $fromForest;
+        return new Hug('Forest');
     }
 
     public function returnsMany(): array
     {
-        $fromJenny = new Hug();
-        $fromJenny->from = 'Jenny';
-
-        $fromForest = new Hug();
-        $fromForest->from = 'Forest';
-
         return [
-            $fromJenny,
-            $fromForest,
+            new Hug('Jenny'),
+            new Hug('Forest'),
         ];
     }
 
@@ -221,5 +212,13 @@ final class HugController
  */
 final class Hug
 {
-    public string $from;
+    /**
+     * @psalm-readonly
+     */
+    public string $to;
+
+    public function __construct(string $to)
+    {
+        $this->to = $to;
+    }
 }

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -18,7 +18,7 @@ use Violines\RestBundle\Tests\Stubs\MimeTypes;
 use Violines\RestBundle\ViolinesRestBundle;
 
 /**
- * @covers \Violines\RestBundle\ViolinesRestBundle
+ * @coversNothing
  */
 final class ControllerTest extends TestCase
 {

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -67,22 +67,19 @@ final class ControllerTest extends TestCase
        JSON, $response->getContent());
     }
 
-    public function testReconstitutesOnetoRequest(): void
+    public function testReconstitutesOne(): void
     {
         $submitted = <<<JSON
             {"to":"Jenny"}
         JSON;
 
-        $request = Request::create('/reconstitutesOne', Request::METHOD_POST, [], [], [], [], $submitted);
-        $request->headers->set('Content-Type', MimeTypes::APPLICATION_JSON);
-        $request->headers->set('Accept', MimeTypes::APPLICATION_JSON);
-
+        $request = $this->createPostRequest('/reconstitutesOne', $submitted);
         $response = $this->app->handle($request);
 
         self::assertJsonStringEqualsJsonString($submitted, $response->getContent());
     }
 
-    public function testReconstitutesMultipletoRequest(): void
+    public function testReconstitutesMultiple(): void
     {
         $submitted = <<<JSON
             [
@@ -91,9 +88,7 @@ final class ControllerTest extends TestCase
             ]
         JSON;
 
-        $request = Request::create('reconstitutesMany', Request::METHOD_POST, [], [], [], [], $submitted);
-        $request->headers->set('Content-Type', MimeTypes::APPLICATION_JSON);
-        $request->headers->set('Accept', MimeTypes::APPLICATION_JSON);
+        $request = $this->createPostRequest('reconstitutesMany', $submitted);
 
         $response = $this->app->handle($request);
 
@@ -110,6 +105,15 @@ final class ControllerTest extends TestCase
 
         $fs = new Filesystem();
         $fs->remove($tempDir);
+    }
+
+    private function createPostRequest(string $uri, string $body): Request
+    {
+        $request = Request::create($uri, Request::METHOD_POST, [], [], [], [], $body);
+        $request->headers->set('Content-Type', MimeTypes::APPLICATION_JSON);
+        $request->headers->set('Accept', MimeTypes::APPLICATION_JSON);
+
+        return $request;
     }
 }
 

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Violines\RestBundle\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+use Violines\RestBundle\Tests\Stubs\MimeTypes;
+use Violines\RestBundle\ViolinesRestBundle;
+
+/**
+ * @covers \Violines\RestBundle\ViolinesRestBundle
+ */
+final class ControllerTest extends TestCase
+{
+    private TestKernel $app;
+
+    protected function setUp(): void
+    {
+        $this->deleteTempDir();
+
+        $this->app = new TestKernel();
+        $this->app->boot();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTempDir();
+    }
+
+    public function testReturnsOne(): void
+    {
+        $request = Request::create('/returnsOne');
+        $request->headers->set('Accept', MimeTypes::APPLICATION_JSON);
+
+        $response = $this->app->handle($request);
+
+        self::assertSame(MimeTypes::APPLICATION_JSON, $response->headers->get('Content-Type'));
+        self::assertJsonStringEqualsJsonString(<<<JSON
+            {"from":"Forest"}
+       JSON, $response->getContent());
+    }
+
+    public function testReturnsMany(): void
+    {
+        $request = Request::create('/returnsMany');
+        $request->headers->set('Accept', MimeTypes::APPLICATION_JSON);
+
+        $response = $this->app->handle($request);
+
+        self::assertSame(MimeTypes::APPLICATION_JSON, $response->headers->get('Content-Type'));
+        self::assertJsonStringEqualsJsonString(<<<JSON
+            [
+                {"from":"Jenny"},
+                {"from":"Forest"}
+            ]
+       JSON, $response->getContent());
+    }
+
+    public function testReconstitutesOneFromRequest(): void
+    {
+        $submitted = <<<JSON
+            {"from":"Jenny"}
+        JSON;
+
+        $request = Request::create('/reconstitutesOne', Request::METHOD_POST, [], [], [], [], $submitted);
+        $request->headers->set('Content-Type', MimeTypes::APPLICATION_JSON);
+        $request->headers->set('Accept', MimeTypes::APPLICATION_JSON);
+
+        $response = $this->app->handle($request);
+
+        self::assertJsonStringEqualsJsonString($submitted, $response->getContent());
+    }
+
+    public function testReconstitutesMultipleFromRequest(): void
+    {
+        $submitted = <<<JSON
+            [
+                {"from":"Jenny"},
+                {"from":"Forest"}
+            ]
+        JSON;
+
+        $request = Request::create('reconstitutesMany', Request::METHOD_POST, [], [], [], [], $submitted);
+        $request->headers->set('Content-Type', MimeTypes::APPLICATION_JSON);
+        $request->headers->set('Accept', MimeTypes::APPLICATION_JSON);
+
+        $response = $this->app->handle($request);
+
+        self::assertJsonStringEqualsJsonString($submitted, $response->getContent());
+    }
+
+    private function deleteTempDir()
+    {
+        if (!file_exists($dir = sys_get_temp_dir() . '/' . Kernel::VERSION . '/CrudControllerTestKernel')) {
+            return;
+        }
+
+        $fs = new Filesystem();
+        $fs->remove($dir);
+    }
+}
+
+/** @internal  */
+final class TestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+
+    public function __construct()
+    {
+        parent::__construct('test', false);
+    }
+
+    public function registerBundles(): array
+    {
+        return [
+            new FrameworkBundle(),
+            new ViolinesRestBundle(),
+        ];
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+        $routes->addRoute(new Route('/returnsOne', [
+            '_controller' => HugController::class . '::returnsOne',
+        ]));
+
+        $routes->addRoute(new Route('/returnsMany', [
+            '_controller' => HugController::class . '::returnsMany',
+        ]));
+
+        $routes->addRoute(new Route('/reconstitutesOne', [
+            '_controller' => HugController::class . '::reconstitutesOne',
+        ]));
+
+        $routes->addRoute(new Route('reconstitutesMany', [
+            '_controller' => HugController::class . '::reconstitutesMany',
+        ]));
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir() . '/' . Kernel::VERSION . '/CrudControllerTestKernel/cache/' . $this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir() . '/' . Kernel::VERSION . '/CrudControllerTestKernel/logs';
+    }
+}
+
+final class HugController
+{
+    public function returnsOne(): Hug
+    {
+        $fromForest = new Hug();
+        $fromForest->from = 'Forest';
+
+        return $fromForest;
+    }
+
+    public function returnsMany(): array
+    {
+        $fromJenny = new Hug();
+        $fromJenny->from = 'Jenny';
+
+        $fromForest = new Hug();
+        $fromForest->from = 'Forest';
+
+        return [
+            $fromJenny,
+            $fromForest,
+        ];
+    }
+
+    public function reconstitutesOne(Hug $hug): Hug
+    {
+        return $hug;
+    }
+
+    /**
+     * @return iterable<Hug>
+     */
+    public function reconstitutesMany(Hug ...$hugs): iterable
+    {
+        return $hugs;
+    }
+}
+
+/**
+ * @internal
+ * @Violines\RestBundle\HttpApi\HttpApi
+ */
+final class Hug
+{
+    public string $from;
+}

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 use Violines\RestBundle\Tests\Stubs\MimeTypes;
 use Violines\RestBundle\ViolinesRestBundle;
+use function sys_get_temp_dir;
 
 /**
  * @coversNothing
@@ -99,14 +100,16 @@ final class ControllerTest extends TestCase
         self::assertJsonStringEqualsJsonString($submitted, $response->getContent());
     }
 
-    private function deleteTempDir()
+    private function deleteTempDir(): void
     {
-        if (!file_exists($dir = sys_get_temp_dir() . '/' . Kernel::VERSION . '/CrudControllerTestKernel')) {
+        $tempDir = TestKernel::getTempDir();
+
+        if (!file_exists($tempDir)) {
             return;
         }
 
         $fs = new Filesystem();
-        $fs->remove($dir);
+        $fs->remove($tempDir);
     }
 }
 
@@ -154,12 +157,23 @@ final class TestKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir() . '/' . Kernel::VERSION . '/CrudControllerTestKernel/cache/' . $this->environment;
+        return self::getTempDir() . '/cache/';
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir() . '/' . Kernel::VERSION . '/CrudControllerTestKernel/logs';
+        return self::getTempDir() . '/logs';
+    }
+
+    public static function getTempDir(): string
+    {
+        $parts = [
+            sys_get_temp_dir(),
+            ControllerTest::class,
+            Kernel::VERSION,
+        ];
+
+        return implode('/', $parts);
     }
 }
 


### PR DESCRIPTION
Unittests are way better, but at some point we should validate
that the integration with the framework works as intended.

Also these kind of tests are great for documenation purpose,
since one can read them and exactly knows how requests/responses
will look like an a real world application.

I tried to focus on the serialization / deseralization process here and hence
did not use any `OK`-Responses.

Let me know what you think about this kind of tests.